### PR TITLE
ADB-2720: fix(trailing dot)

### DIFF
--- a/src/openssl/ssl-keypair-certificate.cpp
+++ b/src/openssl/ssl-keypair-certificate.cpp
@@ -383,9 +383,9 @@ std::set<std::string> SSLKeypairCertificate::alternate_names() const
                 auto cert_name = std::string(reinterpret_cast<const char*>(raw_cert_name),
                                              strlen(reinterpret_cast<const char*>(raw_cert_name)));
                 // Check if FQDN ends with "." since it is valid and we can ignore the dot
-                if (cert_name[cert_name.size() - 1] == '.')
+                if (!cert_name.empty() && cert_name.back() == '.')
                 {
-                    cert_name[cert_name.size() - 1] = '\0';
+                    cert_name.pop_back();
                 }
                 // Add to the final list of alternate names
                 sans.emplace(cert_name);


### PR DESCRIPTION
# Fix: strip trailing dot from DNS SANs in `alternate_names()`

## Problem

GCP Cloud SQL instances using Private Service Connect (PSC) issue TLS server certificates
where the DNS SAN contains a trailing dot (e.g. `DNS:hostname.us-central1.sql.goog.`).
This is technically invalid per RFC 5280 but is a known GCP behaviour.

`alternate_names()` already had code intended to handle this, but used:

```cpp
cert_name[cert_name.size() - 1] = '\0';
```

This replaces the dot with a null byte but **does not shrink the `std::string`** — the
string length stays the same. As a result, `is_valid_hostname()` was comparing
`"hostname\0"` (len N+1) against `"hostname"` (len N), which never matches, causing
certificate validation to always fail for PSC MSSQL targets.

The bug was hard to spot because `fmt::join` stops at the embedded null byte when logging,
making the SAN appear correctly stripped in SIA's logs even though it wasn't.

## Fix

Replace `= '\0'` with `pop_back()`, which actually removes the last character and shrinks
the string:

```cpp
// Before
cert_name[cert_name.size() - 1] = '\0';

// After
cert_name.pop_back();
```

## Impact

Without this fix, certificate validation fails for any GCP Cloud SQL PSC instance
(specifically SQL Server) even when the CA cert and hostname are correctly configured.
PostgreSQL and MySQL use PSA which does not exhibit this trailing dot behaviour, so they
were unaffected.

## Testing on side proxy in integ-dev
works!
<img width="770" height="461" alt="image" src="https://github.com/user-attachments/assets/7a7399d0-690e-4939-b1f9-bd0f433af14f" />


## References

- GCP PSC SQL Server trailing dot behaviour confirmed by direct inspection of issued certs
- Related Go issue (same root cause, different stack): https://github.com/golang/go/issues/75828
- OpenSSL hostname validation and trailing dots: https://github.com/openssl/openssl/issues/11560
